### PR TITLE
Make compatible with Ember 2.X

### DIFF
--- a/addon/components/ivy-redactor.js
+++ b/addon/components/ivy-redactor.js
@@ -94,13 +94,13 @@ export default Ember.Component.extend({
   }),
 
   _setupRedactorCallbacks: function(options) {
-    Ember.EnumerableUtils.forEach(this.get('redactorCallbacks'), function(name) {
+    Ember.makeArray(this.get('redactorCallbacks')).forEach(function(name) {
       options[name] = Ember.run.bind(this, name);
     }, this);
   },
 
   _setupRedactorSettings: function(options) {
-    Ember.EnumerableUtils.forEach(this.get('redactorSettings'), function(key) {
+    Ember.makeArray(this.get('redactorSettings')).forEach(function(key) {
       if (key in this) {
         options[key] = this.get(key);
       }

--- a/blueprints/ivy-redactor/index.js
+++ b/blueprints/ivy-redactor/index.js
@@ -1,10 +1,6 @@
 /* jshint node:true */
 
 module.exports = {
-  afterInstall: function() {
-    return this.addBowerPackageToProject('polyfills-pkg');
-  },
-
   normalizeEntityName: function() {
   }
 };


### PR DESCRIPTION
In Ember 2.X,  `Ember.EnumerableUtils` is gone. 

Using `Ember.makeArray` we can coerce this value to be an `Ember.Array`, and be sure that it will have `forEach`, even in older browser, mantaining Ember 1.X and IE8 support but also working in Ember 2.
